### PR TITLE
Enable GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Open Neural Network Exchange (ONNX) is an open standard for representing mac
     ```
 
 ## Live demonstration
-https://bugz-mnist.herokuapp.com/
+https://harjyotbagga.github.io/MNIST-on-the-web
 
 ## Contributing
 


### PR DESCRIPTION
Hi, just found this, very cool!

Looks like the Heroku link isn't working anymore. Would you consider enabling GitHub Pages on your repo? Confirmed in a fork that it works.